### PR TITLE
feat: Add pre-commit hook and CI check for code generation

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -27,6 +27,10 @@ jobs:
       - run: flutter --version
       - run: flutter pub get
       - run: cd example && flutter pub get
+      - name: Check if generated files are up to date
+        run: |
+          dart run build_runner build --delete-conflicting-outputs
+          git diff --exit-code --quiet || (echo "Generated files are outdated. Please run 'dart run build_runner build --delete-conflicting-outputs' and commit the changes." && exit 1)
       - name: Lint analysis
         run: dart analyze --fatal-infos
       - name: Dart format

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Run build_runner and stage any changes
+dart run build_runner build --delete-conflicting-outputs
+git add .

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
 # Run build_runner and stage any changes
 dart run build_runner build --delete-conflicting-outputs
+if [ $? -ne 0 ]; then  
+  echo "build_runner failed. Aborting commit."  
+  exit 1  
+fi  
 git add .

--- a/README.md
+++ b/README.md
@@ -164,3 +164,40 @@ example/
   formatting
 - Ensure code generation is run after modifying `freezed` models and `riverpod`
   providers
+
+## Automated Code Generation (Pre-commit Hook)
+
+To ensure that generated code is always up-to-date before committing, this project includes a pre-commit hook that automatically runs `dart run build_runner build --delete-conflicting-outputs` and stages any changes.
+
+### Enabling the Pre-commit Hook
+
+You can enable the hook using one of the following methods:
+
+**Method 1: Configure Git's hooksPath (Recommended)**
+
+Run the following command in your terminal at the root of the repository:
+
+```bash
+git config core.hooksPath .hooks
+```
+This tells Git to use the `.hooks` directory for all hooks in this repository.
+
+**Method 2: Manually Link or Copy the Hook**
+
+If you prefer not to change `core.hooksPath`, you can manually create a symbolic link or copy the script into your local `.git/hooks` directory.
+
+First, ensure the `.git/hooks` directory exists. If not, create it:
+```bash
+mkdir -p .git/hooks
+```
+
+Then, either create a symbolic link:
+```bash
+ln -s ../../.hooks/pre-commit .git/hooks/pre-commit
+```
+
+Or, copy the hook script:
+```bash
+cp .hooks/pre-commit .git/hooks/pre-commit
+```
+If you copy the script, make sure it remains executable. The `.hooks/pre-commit` script in the repository already has execute permissions.


### PR DESCRIPTION
This commit introduces improvements to the development workflow by automating checks for code generation.

Key changes:
- Added a pre-commit hook script (`.hooks/pre-commit`) that runs `dart run build_runner build --delete-conflicting-outputs` and stages any resulting changes. This helps ensure that generated files are always up-to-date before committing.
- Updated the GitHub Actions workflow (`.github/workflows/flutter.yml`) to include a step that verifies if generated files are current. The CI will fail if `build_runner` produces any changes, preventing outdated generated code from being merged.
- Added documentation to `README.md` explaining how to set up and use the pre-commit hook.